### PR TITLE
Add support for different collection types

### DIFF
--- a/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableAutoConfiguration.java
+++ b/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableAutoConfiguration.java
@@ -20,6 +20,7 @@
 
 package de.qaware.tools.collectioncacheableforspring;
 
+import de.qaware.tools.collectioncacheableforspring.creator.CollectionCreator;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -32,9 +33,11 @@ import org.springframework.cache.interceptor.CacheOperationSource;
 import org.springframework.cache.interceptor.CacheResolver;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 
+@ComponentScan(basePackageClasses = CollectionCreator.class)
 @Configuration
 @SuppressWarnings("java:S1118")
 // suppress "Utility classes should not have public constructors" as Spring needs a public ctor
@@ -60,7 +63,8 @@ public class CollectionCacheableAutoConfiguration {
     }
 
     private static CacheInterceptor collectionCacheInterceptor(ConfigurableListableBeanFactory beanFactory) {
-        CacheInterceptor interceptor = new CollectionCacheableCacheInterceptor();
+        CacheInterceptor interceptor = new CollectionCacheableCacheInterceptor(
+                beanFactory.getBeanProvider(CollectionCreator.class));
         interceptor.configure(
                 () -> beanFactory.getBeanProvider(CacheErrorHandler.class).getIfAvailable(),
                 () -> beanFactory.getBeanProvider(KeyGenerator.class).getIfAvailable(),

--- a/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableAutoConfiguration.java
+++ b/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableAutoConfiguration.java
@@ -65,6 +65,7 @@ public class CollectionCacheableAutoConfiguration {
     private static CacheInterceptor collectionCacheInterceptor(ConfigurableListableBeanFactory beanFactory) {
         CacheInterceptor interceptor = new CollectionCacheableCacheInterceptor(
                 beanFactory.getBeanProvider(CollectionCreator.class));
+        interceptor.setBeanFactory(beanFactory);
         interceptor.configure(
                 () -> beanFactory.getBeanProvider(CacheErrorHandler.class).getIfAvailable(),
                 () -> beanFactory.getBeanProvider(KeyGenerator.class).getIfAvailable(),

--- a/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableCacheAnnotationParser.java
+++ b/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableCacheAnnotationParser.java
@@ -137,7 +137,7 @@ public class CollectionCacheableCacheAnnotationParser implements CacheAnnotation
 
     private static void validateMethodArguments(Method method) {
         Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length != 1 || !parameterTypes[0].equals(Collection.class)) {
+        if (parameterTypes.length != 1 || !Collection.class.isAssignableFrom(parameterTypes[0])) {
             throw new IllegalStateException(String.format(
                     MESSAGE_INVALID_COLLECTION_CACHEABLE_ANNOTATION_CONFIGURATION +
                             " Did not find exactly one Collection argument",

--- a/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/creator/CollectionCreator.java
+++ b/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/creator/CollectionCreator.java
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Collection Cacheable for Spring :: Starter
+ * %%
+ * Copyright (C) 2020 QAware GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.qaware.tools.collectioncacheableforspring.creator;
+
+import java.util.Collection;
+
+public interface CollectionCreator {
+
+    boolean canHandle(Class<?> cls);
+
+    <T> Collection<T> create(Collection<T> collection);
+}

--- a/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/creator/DefaultCollectionCreator.java
+++ b/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/creator/DefaultCollectionCreator.java
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * Collection Cacheable for Spring :: Starter
+ * %%
+ * Copyright (C) 2020 QAware GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.qaware.tools.collectioncacheableforspring.creator;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+@Component
+public class DefaultCollectionCreator
+        implements CollectionCreator {
+    @Override
+    public boolean canHandle(Class<?> cls) {
+        return cls.isAssignableFrom(LinkedList.class);
+    }
+
+    @Override
+    public <T> Collection<T> create(Collection<T> collection) {
+        return new LinkedList<>(collection);
+    }
+}

--- a/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/creator/SetCollectionCreator.java
+++ b/collection-cacheable-for-spring-starter/src/main/java/de/qaware/tools/collectioncacheableforspring/creator/SetCollectionCreator.java
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * Collection Cacheable for Spring :: Starter
+ * %%
+ * Copyright (C) 2020 QAware GmbH
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package de.qaware.tools.collectioncacheableforspring.creator;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashSet;
+
+@Component
+public class SetCollectionCreator
+        implements CollectionCreator {
+    @Override
+    public boolean canHandle(Class<?> cls) {
+        return cls.isAssignableFrom(HashSet.class);
+    }
+
+    @Override
+    public <T> Collection<T> create(Collection<T> collection) {
+        return new HashSet<>(collection);
+    }
+}

--- a/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableIntTest.java
+++ b/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableIntTest.java
@@ -14,10 +14,19 @@ import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static de.qaware.tools.collectioncacheableforspring.CollectionCacheableTestRepository.CACHE_NAME;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -97,6 +106,7 @@ public class CollectionCacheableIntTest {
 
         // Throws exception if signature has classes that are not implemented
         assertThatThrownBy(() -> sut.findByArrayList(new ArrayList<>(setOf(SOME_KEY_1, SOME_KEY_2))));
+        assertThatThrownBy(() -> sut.findByLinkedHashSet(new LinkedHashSet<>(setOf(SOME_KEY_1, SOME_KEY_2))));
     }
 
     @Test

--- a/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableIntTest.java
+++ b/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableIntTest.java
@@ -96,7 +96,7 @@ public class CollectionCacheableIntTest {
         when(repository.findById(SOME_KEY_2)).thenReturn(SOME_VALUE_2);
 
         // Throws exception if signature has classes that are not implemented
-        assertThatThrownBy(() -> sut.findByIdDeque(new ArrayList<>(setOf(SOME_KEY_1, SOME_KEY_2))));
+        assertThatThrownBy(() -> sut.findByArrayList(new ArrayList<>(setOf(SOME_KEY_1, SOME_KEY_2))));
     }
 
     @Test

--- a/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableIntTest.java
+++ b/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableIntTest.java
@@ -14,16 +14,10 @@ import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static de.qaware.tools.collectioncacheableforspring.CollectionCacheableTestRepository.CACHE_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -79,6 +73,30 @@ public class CollectionCacheableIntTest {
 
         verify(repository, times(1)).findById(SOME_KEY_1);
         verify(repository, times(1)).findById(SOME_KEY_2);
+    }
+
+    @Test
+    public void findByIdSet() throws Exception {
+        when(repository.findById(SOME_KEY_1)).thenReturn(SOME_VALUE_1);
+        when(repository.findById(SOME_KEY_2)).thenReturn(SOME_VALUE_2);
+
+        // find it two times, but database is only asked once
+        assertThat(sut.findByIdSet(setOf(SOME_KEY_1, SOME_KEY_2)))
+                .containsOnly(entry(SOME_KEY_1, SOME_VALUE_1), entry(SOME_KEY_2, SOME_VALUE_2));
+        assertThat(sut.findByIdSet(setOf(SOME_KEY_1, SOME_KEY_2)))
+                .containsOnly(entry(SOME_KEY_1, SOME_VALUE_1), entry(SOME_KEY_2, SOME_VALUE_2));
+
+        verify(repository, times(1)).findById(SOME_KEY_1);
+        verify(repository, times(1)).findById(SOME_KEY_2);
+    }
+
+    @Test
+    public void throwsExceptionOnUnknownClasses() throws Exception {
+        when(repository.findById(SOME_KEY_1)).thenReturn(SOME_VALUE_1);
+        when(repository.findById(SOME_KEY_2)).thenReturn(SOME_VALUE_2);
+
+        // Throws exception if signature has classes that are not implemented
+        assertThatThrownBy(() -> sut.findByIdDeque(new ArrayList<>(setOf(SOME_KEY_1, SOME_KEY_2))));
     }
 
     @Test

--- a/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableTestRepository.java
+++ b/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableTestRepository.java
@@ -3,7 +3,12 @@ package de.qaware.tools.collectioncacheableforspring;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
 
 
 @CacheConfig(cacheNames = CollectionCacheableTestRepository.CACHE_NAME)
@@ -38,6 +43,11 @@ public class CollectionCacheableTestRepository {
 
     @CollectionCacheable(CACHE_NAME)
     public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByArrayList(ArrayList<CollectionCacheableTestId> ids) {
+        return findByIdsInternal(ids);
+    }
+
+    @CollectionCacheable(CACHE_NAME)
+    public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByLinkedHashSet(LinkedHashSet<CollectionCacheableTestId> ids) {
         return findByIdsInternal(ids);
     }
 

--- a/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableTestRepository.java
+++ b/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableTestRepository.java
@@ -37,7 +37,7 @@ public class CollectionCacheableTestRepository {
     }
 
     @CollectionCacheable(CACHE_NAME)
-    public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByIdDeque(ArrayList<CollectionCacheableTestId> ids) {
+    public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByArrayList(ArrayList<CollectionCacheableTestId> ids) {
         return findByIdsInternal(ids);
     }
 

--- a/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableTestRepository.java
+++ b/collection-cacheable-for-spring-starter/src/test/java/de/qaware/tools/collectioncacheableforspring/CollectionCacheableTestRepository.java
@@ -3,9 +3,7 @@ package de.qaware.tools.collectioncacheableforspring;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.Cacheable;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 
 @CacheConfig(cacheNames = CollectionCacheableTestRepository.CACHE_NAME)
@@ -30,6 +28,16 @@ public class CollectionCacheableTestRepository {
 
     @CollectionCacheable(CACHE_NAME)
     public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByIds(Collection<CollectionCacheableTestId> ids) {
+        return findByIdsInternal(ids);
+    }
+
+    @CollectionCacheable(CACHE_NAME)
+    public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByIdSet(Set<CollectionCacheableTestId> ids) {
+        return findByIdsInternal(ids);
+    }
+
+    @CollectionCacheable(CACHE_NAME)
+    public Map<CollectionCacheableTestId, CollectionCacheableTestValue> findByIdDeque(ArrayList<CollectionCacheableTestId> ids) {
         return findByIdsInternal(ids);
     }
 


### PR DESCRIPTION
## Issue
`@CachableCollection` supports only Collection<?> arguments, it's not ideal for real use, often programmers use Set<?> or List<?>

## Proposed solution
Replace check `arg[0].class.equals(Collection.class)` with `Collection.class.isAssignableFrom(arg[0].class)`.

We have to decide what type of collection we have to create. The condition is that `arg[0].class` has to be assignable from this collection. To deal with it `CollectionCreator` interface is provided. Currently it consists two implementations: `DefaultCollectionCreator` which creates LinkedList, `SetCollectionCreator` that works with HashSet